### PR TITLE
Fixed 'add new event' view height not being calculated correctly

### DIFF
--- a/JZCalendarWeekView/JZLongPressWeekView.swift
+++ b/JZCalendarWeekView/JZLongPressWeekView.swift
@@ -396,7 +396,7 @@ extension JZLongPressWeekView: UIGestureRecognizerDelegate {
         
         if state == .began {
             
-            currentEditingInfo.cellSize = currentLongPressType == .move ? currentMovingCell.frame.size : CGSize(width: flowLayout.sectionWidth, height: flowLayout.hourHeight * CGFloat(addNewDurationMins/60))
+            currentEditingInfo.cellSize = currentLongPressType == .move ? currentMovingCell.frame.size : CGSize(width: flowLayout.sectionWidth, height: flowLayout.hourHeight * CGFloat(addNewDurationMins)/60)
             pressPosition = currentLongPressType == .move ? (pointInCollectionView.x - currentMovingCell.frame.origin.x, pointInCollectionView.y - currentMovingCell.frame.origin.y) :
                                                             (currentEditingInfo.cellSize.width/2, currentEditingInfo.cellSize.height/2)
             longPressViewStartDate = getLongPressViewStartDate(pointInCollectionView: pointInCollectionView, pointInSelfView: pointInSelfView)


### PR DESCRIPTION
The 'addNewDurationMins' property for the 'add new event' height calculation is being cast to CGFloat too late, resulting in incorrect height for fractional duration hours.