### PR TITLE
Swift 5 Compiler support

### DIFF
--- a/JZCalendarWeekView/JZWeekViewFlowLayout.swift
+++ b/JZCalendarWeekView/JZWeekViewFlowLayout.swift
@@ -40,7 +40,10 @@ open class JZWeekViewFlowLayout: UICollectionViewFlowLayout {
     open var contentsMargin: UIEdgeInsets { return UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0) }
     open var itemMargin: UIEdgeInsets { return UIEdgeInsets(top: 1, left: 1, bottom: 1, right: 1) }
     /// weekview contentSize height
-    open var maxSectionHeight: CGFloat { return columnHeaderHeight + hourHeight * 24 + contentsMargin.top + contentsMargin.bottom + allDayHeaderHeight }
+    open var maxSectionHeight: CGFloat { 
+        let height = hourHeight * 24 // statement too long for Swift 5 compiler
+        return columnHeaderHeight + height + contentsMargin.top + contentsMargin.bottom + allDayHeaderHeight
+    }
     
     let minOverlayZ = 1000  // Allows for 900 items in a section without z overlap issues
     let minCellZ = 100      // Allows for 100 items in a section's background


### PR DESCRIPTION
Some code snippets in the library did not compile in XCode 10.2 with Swift 5 because of a type-checking issue for longer statements - this PR fixes that.