### PR TITLE
54: cell division issue in cell rendering 

### DIFF
--- a/JZCalendarWeekView/JZWeekViewFlowLayout.swift
+++ b/JZCalendarWeekView/JZWeekViewFlowLayout.swift
@@ -537,7 +537,7 @@ open class JZWeekViewFlowLayout: UICollectionViewFlowLayout {
                 // Determine the number of divisions needed (maximum number of currently overlapping items)
                 var divisions = 1
                 
-                for currentY in stride(from: minY, to: maxY, by: 1) {
+                for currentY in stride(from: minY, to: maxY, by: 0.1) {
                     var numberItemsForCurrentY = 0
                     
                     for overlappingItemAttributes in overlappingItems {


### PR DESCRIPTION
See issue details here: https://github.com/zjfjack/JZCalendarWeekView/issues/54

From
`for currentY in stride(from: minY, to: maxY, by: 1) {`

To
`for currentY in stride(from: minY, to: maxY, by: 0.1) {`

Because if minY/maxY diff is < 1, stride by 1 will skip some items if too close, therefore 0.1. It is a division issue, apparently.