### PR TITLE
Added eventHeight property to JZAllDayHeader

### DIFF
--- a/JZCalendarWeekView/JZBaseWeekView.swift
+++ b/JZCalendarWeekView/JZBaseWeekView.swift
@@ -558,7 +558,7 @@ extension JZBaseWeekView: UICollectionViewDelegate, UICollectionViewDelegateFlow
         // current section will always get current section, applied floor Int here
         let currentSection = Int(currentContentOffset.x / flowLayout.sectionWidth)
         let currentPage = scrollType == .sectionScroll ? currentSection : (currentSection >= numOfDays ? 1 : 0)  // The divider section for 0 and 1 page is at numOfDays
-        let isVelocitySatisfied = abs(velocity.x) > 0.2
+        let isVelocitySatisfied = abs(velocity.x) > 0.4
         var shouldScrollToPage: Int
         
         if isVelocitySatisfied {

--- a/JZCalendarWeekView/ReusableViews/JZAllDayHeader.swift
+++ b/JZCalendarWeekView/ReusableViews/JZAllDayHeader.swift
@@ -10,6 +10,8 @@ import UIKit
 
 open class JZAllDayHeader: UICollectionReusableView {
     
+    /// The height of an allDayEvent within the allDayHeader (default: 25)
+    public var eventHeight: CGFloat = 25
     let scrollView = UIScrollView()
     let stackView = UIStackView()
     
@@ -61,7 +63,7 @@ open class JZAllDayHeader: UICollectionReusableView {
             }
         }
         views.forEach {
-            $0.heightAnchor.constraint(equalToConstant: 25).isActive = true
+            $0.heightAnchor.constraint(equalToConstant: eventHeight).isActive = true
             stackView.addArrangedSubview($0)
         }
     }


### PR DESCRIPTION
This allows the library user to manipulate the height of an allDayEvent within the header.
In combination with overriding JZBaseWeekView's getAllDayHeaderHeight(maxEventsCount: Int) func, it's now very easy to change the height of the allDayHeader and the containing events.


