### PR TITLE
Adds support for dark-mode and accessibility starting with iOS 13.

### DIFF
--- a/JZCalendarWeekView/JZBaseWeekView.swift
+++ b/JZCalendarWeekView/JZBaseWeekView.swift
@@ -98,7 +98,7 @@ open class JZBaseWeekView: UIView {
         collectionView.bounces = false
         collectionView.showsVerticalScrollIndicator = false
         collectionView.showsHorizontalScrollIndicator = false
-        collectionView.backgroundColor = UIColor.white
+        collectionView.backgroundColor = JZWeekViewColors.background
         addSubview(collectionView)
         collectionView.setAnchorConstraintsFullSizeTo(view: self)
 

--- a/JZCalendarWeekView/JZLongPressWeekView.swift
+++ b/JZCalendarWeekView/JZLongPressWeekView.swift
@@ -113,7 +113,7 @@ open class JZLongPressWeekView: JZBaseWeekView {
     public var longPressTimeLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 14)
-        label.textColor = UIColor.gray
+        label.textColor = JZWeekViewColors.secondaryLabel
         return label
     }()
     /// The moving cell contentView layer opacity (when you move the existing cell, the previous cell will be translucent)

--- a/JZCalendarWeekView/ReusableViews/JZAllDayCorner.swift
+++ b/JZCalendarWeekView/ReusableViews/JZAllDayCorner.swift
@@ -20,11 +20,11 @@ open class JZAllDayCorner: UICollectionReusableView {
     }
 
     open func setupUI() {
-        self.backgroundColor = .white
+        self.backgroundColor = JZWeekViewColors.background
         self.clipsToBounds = true
         self.addSubview(lblTitle)
         lblTitle.text = "all-day"
-        lblTitle.textColor = JZWeekViewColors.allDayHeader
+        lblTitle.textColor = JZWeekViewColors.secondaryLabel
         lblTitle.font = UIFont.systemFont(ofSize: 12)
         // Support iPhone X Landscape state (same as JZRowHeader)
         lblTitle.setAnchorCenterVerticallyTo(view: self, trailingAnchor: (self.trailingAnchor, -2))
@@ -32,7 +32,7 @@ open class JZAllDayCorner: UICollectionReusableView {
 
     open func setupBottomDivider() {
         let bottomDivider = UIView()
-        bottomDivider.backgroundColor = JZWeekViewColors.gridLine
+        bottomDivider.backgroundColor = JZWeekViewColors.separator
         addSubview(bottomDivider)
         bottomDivider.setAnchorConstraintsEqualTo(heightAnchor: 0.5, bottomAnchor: (bottomAnchor, 0), leadingAnchor: (leadingAnchor, 0), trailingAnchor: (trailingAnchor, 0))
     }

--- a/JZCalendarWeekView/ReusableViews/JZAllDayHeaderBackground.swift
+++ b/JZCalendarWeekView/ReusableViews/JZAllDayHeaderBackground.swift
@@ -14,7 +14,7 @@ open class JZAllDayHeaderBackground: UICollectionReusableView {
         super.init(frame: frame)
 
         self.clipsToBounds = true
-        self.backgroundColor = .white
+        self.backgroundColor = JZWeekViewColors.background
         setupBottomDivider()
     }
 
@@ -24,7 +24,7 @@ open class JZAllDayHeaderBackground: UICollectionReusableView {
 
     open func setupBottomDivider() {
         let bottomDivider = UIView()
-        bottomDivider.backgroundColor = JZWeekViewColors.gridLine
+        bottomDivider.backgroundColor = JZWeekViewColors.separator
         addSubview(bottomDivider)
         bottomDivider.setAnchorConstraintsEqualTo(heightAnchor: 0.5, bottomAnchor: (bottomAnchor, 0), leadingAnchor: (leadingAnchor, 0), trailingAnchor: (trailingAnchor, 0))
     }

--- a/JZCalendarWeekView/ReusableViews/JZColumnHeader.swift
+++ b/JZCalendarWeekView/ReusableViews/JZColumnHeader.swift
@@ -47,11 +47,11 @@ open class JZColumnHeader: UICollectionReusableView {
         lblWeekday.text = dateFormatter.shortWeekdaySymbols[weekday].uppercased()
 
         if date.isToday {
-            lblDay.textColor = JZWeekViewColors.today
-            lblWeekday.textColor = JZWeekViewColors.today
+            lblDay.textColor = JZWeekViewColors.blue
+            lblWeekday.textColor = JZWeekViewColors.blue
         } else {
-            lblDay.textColor = JZWeekViewColors.columnHeaderDay
-            lblWeekday.textColor = JZWeekViewColors.columnHeaderDay
+            lblDay.textColor = JZWeekViewColors.secondaryLabel
+            lblWeekday.textColor = JZWeekViewColors.secondaryLabel
         }
     }
 

--- a/JZCalendarWeekView/ReusableViews/JZColumnHeaderBackground.swift
+++ b/JZCalendarWeekView/ReusableViews/JZColumnHeaderBackground.swift
@@ -13,14 +13,14 @@ open class JZColumnHeaderBackground: UICollectionReusableView {
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = UIColor.white
+        backgroundColor = JZWeekViewColors.background
         self.clipsToBounds = true
         setupBottomDivider()
     }
 
     open func setupBottomDivider() {
         let bottomDivider = UIView()
-        bottomDivider.backgroundColor = JZWeekViewColors.gridLine
+        bottomDivider.backgroundColor = JZWeekViewColors.separator
         addSubview(bottomDivider)
         bottomDivider.setAnchorConstraintsEqualTo(heightAnchor: 0.5, bottomAnchor: (bottomAnchor, 0), leadingAnchor: (leadingAnchor, 0), trailingAnchor: (trailingAnchor, 0))
     }

--- a/JZCalendarWeekView/ReusableViews/JZCornerHeader.swift
+++ b/JZCalendarWeekView/ReusableViews/JZCornerHeader.swift
@@ -14,13 +14,13 @@ open class JZCornerHeader: UICollectionReusableView {
     public override init(frame: CGRect) {
         super.init(frame: .zero)
 
-        self.backgroundColor = .white
+        self.backgroundColor = JZWeekViewColors.background
         setupBottomDivider()
     }
 
     open func setupBottomDivider() {
         let bottomDivider = UIView()
-        bottomDivider.backgroundColor = JZWeekViewColors.gridLine
+        bottomDivider.backgroundColor = JZWeekViewColors.separator
         addSubview(bottomDivider)
         bottomDivider.setAnchorConstraintsEqualTo(heightAnchor: 0.5, bottomAnchor: (bottomAnchor, 0), leadingAnchor: (leadingAnchor, 0), trailingAnchor: (trailingAnchor, 0))
     }

--- a/JZCalendarWeekView/ReusableViews/JZCurrentTimelinePage.swift
+++ b/JZCalendarWeekView/ReusableViews/JZCurrentTimelinePage.swift
@@ -25,10 +25,10 @@ open class JZCurrentTimelinePage: UICollectionReusableView {
         ballView.setAnchorCenterVerticallyTo(view: self, widthAnchor: ballSize, heightAnchor: ballSize, leadingAnchor: (leadingAnchor, 2))
         lineView.setAnchorCenterVerticallyTo(view: self, heightAnchor: 1, leadingAnchor: (leadingAnchor, 0), trailingAnchor: (trailingAnchor, 0))
 
-        ballView.backgroundColor = JZWeekViewColors.appleCalendarRed
+        ballView.backgroundColor = JZWeekViewColors.red
         ballView.layer.cornerRadius = ballSize/2
         ballView.isHidden = true
-        lineView.backgroundColor = JZWeekViewColors.appleCalendarRed
+        lineView.backgroundColor = JZWeekViewColors.red
     }
 
     open func updateView(needShowBallView: Bool) {

--- a/JZCalendarWeekView/ReusableViews/JZCurrentTimelineSection.swift
+++ b/JZCalendarWeekView/ReusableViews/JZCurrentTimelineSection.swift
@@ -25,9 +25,9 @@ open class JZCurrentTimelineSection: UICollectionReusableView {
         halfBallView.setAnchorCenterVerticallyTo(view: self, widthAnchor: halfBallSize, heightAnchor: halfBallSize, leadingAnchor: (leadingAnchor, -5))
         lineView.setAnchorCenterVerticallyTo(view: self, heightAnchor: 1, leadingAnchor: (halfBallView.trailingAnchor, 0), trailingAnchor: (trailingAnchor, 0))
 
-        halfBallView.backgroundColor = JZWeekViewColors.today
+        halfBallView.backgroundColor = JZWeekViewColors.blue
         halfBallView.layer.cornerRadius = halfBallSize/2
-        lineView.backgroundColor = JZWeekViewColors.today
+        lineView.backgroundColor = JZWeekViewColors.blue
         self.clipsToBounds = true
     }
 

--- a/JZCalendarWeekView/ReusableViews/JZGridLine.swift
+++ b/JZCalendarWeekView/ReusableViews/JZGridLine.swift
@@ -13,7 +13,7 @@ open class JZGridLine: UICollectionReusableView {
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = JZWeekViewColors.gridLine
+        backgroundColor = JZWeekViewColors.separator
     }
 
     required public init?(coder aDecoder: NSCoder) {

--- a/JZCalendarWeekView/ReusableViews/JZRowHeader.swift
+++ b/JZCalendarWeekView/ReusableViews/JZRowHeader.swift
@@ -32,7 +32,7 @@ open class JZRowHeader: UICollectionReusableView {
         // Hide all content when colum header height equals 0
         self.clipsToBounds = true
         dateFormatter.dateFormat = "HH:mm"
-        lblTime.textColor = JZWeekViewColors.rowHeaderTime
+        lblTime.textColor = JZWeekViewColors.tertiaryLabel
         lblTime.font = UIFont.systemFont(ofSize: 12)
     }
 

--- a/JZCalendarWeekView/ReusableViews/JZRowHeaderBackground.swift
+++ b/JZCalendarWeekView/ReusableViews/JZRowHeaderBackground.swift
@@ -12,7 +12,7 @@ open class JZRowHeaderBackground: UICollectionReusableView {
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = UIColor.white
+        backgroundColor = JZWeekViewColors.background
 
     }
 

--- a/JZCalendarWeekView/Utils/JZWeekViewColors.swift
+++ b/JZCalendarWeekView/Utils/JZWeekViewColors.swift
@@ -11,14 +11,36 @@ import Foundation
 /// cannot change for now, will implement theme in the future
 class JZWeekViewColors {
 
-    class var columnHeaderWeekday: UIColor { return UIColor(hex: 0x757575) }
-    class var columnHeaderDay: UIColor { return UIColor(hex: 0x757575) }
-    class var allDayHeader: UIColor { return UIColor(hex: 0x757575) }
-    class var rowHeaderTime: UIColor { return UIColor(hex: 0x999999) }
-    class var gridLine: UIColor { return UIColor.lightGray }
-
-    class var today: UIColor { return UIColor(hex: 0x0089FF) }
-    class var appleCalendarRed: UIColor { return UIColor(hex: 0xFC3D39) }
+        class var secondaryLabel: UIColor {
+        if #available(iOS 13, *) {
+            return UIColor.secondaryLabel
+        } else {
+            return UIColor(hex: 0x757575)
+        }
+    }
+    class var tertiaryLabel: UIColor {
+        if #available(iOS 13, *) {
+            return UIColor.tertiaryLabel
+        } else {
+            return UIColor(hex: 0x999999)
+        }
+    }
+    class var separator: UIColor {
+        if #available(iOS 13, *) {
+            return UIColor.separator
+        } else {
+            return UIColor.lightGray
+        }
+    }
+    class var background: UIColor {
+        if #available(iOS 13, *) {
+            return UIColor.systemBackground
+        } else {
+            return UIColor.white
+        }
+    }
+    class var blue: UIColor { return UIColor.systemBlue }
+    class var red: UIColor { return UIColor.systemRed }
 }
 
 extension UIColor {


### PR DESCRIPTION
Previous versions of iOS will work the same as before.

The color mapping that I used in the JZWeekViewColor is as follows.

   UIColor.white --> systemBackground all used to color backgrounds
columnHeaderWeekday: UIColor { return UIColor(hex: 0x757575) } --> secondaryLabel
columnHeaderDay: UIColor { return UIColor(hex: 0x757575) } --> secondaryLabel
allDayHeader: UIColor { return UIColor(hex: 0x757575) } --> secondaryLabel
rowHeaderTime: UIColor { return UIColor(hex: 0x999999) } --> tertiaryLabel
gridLine: UIColor { return UIColor.lightGray } --> separator
today: UIColor { return UIColor(hex: 0x0089FF) } --> systemBlue
appleCalendarRed: UIColor { return UIColor(hex: 0xFC3D39) } --> systemRed

If you have any questions feel free to reach out. This is a fix that we're using at the company I'm working at in order to fully support dark mode and accessibility in our app. Hopefully, it's pretty straightforward.

I renamed a lot of the colors to be more semantic to match the new iOS UIColor naming conventions (with the exception of blue and red). There's a good article on that here. https://nshipster.com/dark-mode/

Thanks so much for your hard work on this pod!