### PR TITLE
Fixes async crash using unowned on baseWeekView

### DIFF
--- a/JZCalendarWeekView.podspec
+++ b/JZCalendarWeekView.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "JZCalendarWeekView"
-  s.version      = "0.7.2"
+  s.version      = "0.7.200"
   s.summary      = "Calendar Week & Day View in iOS Swift"
   s.homepage = "https://github.com/zjfjack/JZCalendarWeekView"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Jeff Zhang" => "zekejeff@gmail.com" }
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "15.0"
   s.source = { :git => "https://github.com/zjfjack/JZCalendarWeekView.git", :tag => s.version }
   s.source_files  = "JZCalendarWeekView/**/*.swift"
 end

--- a/JZCalendarWeekView.xcodeproj/project.pbxproj
+++ b/JZCalendarWeekView.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 				TargetAttributes = {
 					8E023C74206C6E4B00C523BE = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1540;
 						ProvisioningStyle = Automatic;
 					};
 					8E1BA949206B4329007BE13C = {
@@ -371,7 +372,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.zjfjack.JZCalendarWeekViewTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -385,7 +386,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.zjfjack.JZCalendarWeekViewTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -441,7 +442,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -497,7 +498,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -520,7 +521,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = JZCalendarWeekView/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.zjfjack.JZCalendarWeekView;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -544,7 +544,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = JZCalendarWeekView/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.zjfjack.JZCalendarWeekView;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/JZCalendarWeekView/Info.plist
+++ b/JZCalendarWeekView/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.1</string>
+	<string>0.7.200</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/JZCalendarWeekView/JZBaseWeekView.swift
+++ b/JZCalendarWeekView/JZBaseWeekView.swift
@@ -177,7 +177,8 @@ open class JZBaseWeekView: UIView {
         self.scrollableRange.endDate = scrollableRange?.endDate
         self.currentTimelineType = currentTimelineType
 
-        DispatchQueue.main.async { [unowned self] in
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
             // Check the screen orientation when initialisation
             JZWeekViewHelper.viewTransitionHandler(to: UIScreen.main.bounds.size, weekView: self, needRefresh: false)
             self.layoutSubviews()
@@ -283,7 +284,8 @@ open class JZBaseWeekView: UIView {
     ///    - date: this date is the current date in one-day view rather than initDate
     open func updateWeekView(to date: Date) {
         self.initDate = date.startOfDay.add(component: .day, value: -numOfDays)
-        DispatchQueue.main.async { [unowned self] in
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
             self.layoutSubviews()
             self.forceReload()
         }


### PR DESCRIPTION
Stop using unowned self, causes crashes when baseWeekView is not == nil when deallocating.

The developer of this framework was using [unowned self] instead of [weak self] in closures.
This can cause apps / the framework to crash if they use the view in an incorrect manner.